### PR TITLE
fix(ci): Revert semantic-release to v21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: 🚀 Release
         uses: cycjimmy/semantic-release-action@v2
         with:
-          semantic_version: 22
+          semantic_version: 21
           branches: |
             [
               '+([0-9])?(.{+([0-9]),x}).x',

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint": "^8.52.0",
         "eslint-plugin-jest": "^27.4.3",
         "jest": "^29.7.0",
-        "semantic-release": "^22.0.5"
+        "semantic-release": "^21.1.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3109,13 +3109,13 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0.tgz",
-      "integrity": "sha512-uEXyf4Z0AWJuxI9TbSQP5kkIYqus1/E1NcmE7pIv6d6/m/5EJcNWAGR4FOo34vrV26FhEaRVkxFfYzp/M7BKIg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.4.tgz",
+      "integrity": "sha512-pFGn99fn8w4/MHE0otb2A/l5kxgOuxaaauIh4u30ncoTJuqWj4hXTgEJ03REqjS+w1R2vPftSsO26WC61yOcpw==",
       "dev": true,
       "dependencies": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-commits-filter": "^3.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
@@ -3123,7 +3123,7 @@
         "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": "^18.17 || >=20.6.1"
+        "node": ">=18"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/@semantic-release/npm": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.0.tgz",
-      "integrity": "sha512-ozNCiPUp14Xp2rgeY7j96yFTEhDncLSWOJr0IAUr888+ax6fH5xgYkNVv08vpkV8C5GIXBgnGd9coRiOCD6oqQ==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.6.tgz",
+      "integrity": "sha512-DyqHrGE8aUyapA277BB+4kV0C4iMHh3sHzUWdf0jTgp5NNJxVUz76W1f57FB64Ue03him3CBXxFqQD2xGabxow==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^4.0.0",
@@ -3212,7 +3212,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^10.0.0",
+        "npm": "^9.5.0",
         "rc": "^1.2.8",
         "read-pkg": "^8.0.0",
         "registry-auth-token": "^5.0.0",
@@ -3220,7 +3220,7 @@
         "tempy": "^3.0.0"
       },
       "engines": {
-        "node": "^18.17 || >=20"
+        "node": ">=18"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
@@ -3349,13 +3349,13 @@
       }
     },
     "node_modules/@semantic-release/release-notes-generator": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0.tgz",
-      "integrity": "sha512-m7Ds8ComP1KJgA2Lke2xMwE1TOOU40U7AzP4lT8hJ2tUAeicziPz/1GeDFmRkTOkMFlfHvE6kuvMkvU+mIzIDQ==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.7.tgz",
+      "integrity": "sha512-T09QB9ImmNx7Q6hY6YnnEbw/rEJ6a+22LBxfZq+pSAXg/OL/k0siwEm5cK4k1f9dE2Z2mPIjJKKohzUm0jbxcQ==",
       "dev": true,
       "dependencies": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-changelog-writer": "^7.0.0",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-changelog-writer": "^6.0.0",
         "conventional-commits-filter": "^4.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
@@ -3366,10 +3366,19 @@
         "read-pkg-up": "^10.0.0"
       },
       "engines": {
-        "node": "^18.17 || >=20.6.1"
+        "node": ">=18"
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
@@ -3389,18 +3398,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
-    },
-    "node_modules/@sindresorhus/is": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.0",
@@ -3498,6 +3495,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.4.tgz",
+      "integrity": "sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -3824,6 +3827,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/babel-core": {
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
@@ -4147,6 +4159,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001551",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
@@ -4393,35 +4422,36 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-      "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+      "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
       "dev": true,
       "dependencies": {
-        "conventional-commits-filter": "^4.0.0",
+        "conventional-commits-filter": "^3.0.0",
+        "dateformat": "^3.0.3",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "meow": "^12.0.1",
-        "semver": "^7.5.2",
-        "split2": "^4.0.0"
+        "meow": "^8.1.2",
+        "semver": "^7.0.0",
+        "split": "^1.0.1"
       },
       "bin": {
-        "conventional-changelog-writer": "cli.mjs"
+        "conventional-changelog-writer": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
@@ -4440,12 +4470,16 @@
       }
     },
     "node_modules/conventional-commits-filter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
       "dev": true,
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.1"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -4464,6 +4498,18 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/conventional-commits-parser/node_modules/meow": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -4659,6 +4705,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -4674,6 +4729,40 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -4807,67 +4896,49 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "node_modules/emojilib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-      "dev": true
-    },
     "node_modules/env-ci": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-10.0.0.tgz",
-      "integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.1.tgz",
+      "integrity": "sha512-Im2yEWeF4b2RAMAaWvGioXk6m0UNaIjD8hj28j2ij5ldnIFrDQT0+pzDvpbRkcjurhXhf/AsBKv8P2rtmGi9Aw==",
       "dev": true,
       "dependencies": {
-        "execa": "^8.0.0",
+        "execa": "^7.0.0",
         "java-properties": "^1.0.2"
       },
       "engines": {
-        "node": "^18.17 || >=20.6.1"
+        "node": "^16.14 || >=18"
       }
     },
     "node_modules/env-ci/node_modules/execa": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+      "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.3",
-        "get-stream": "^8.0.1",
-        "human-signals": "^5.0.0",
+        "get-stream": "^6.0.1",
+        "human-signals": "^4.3.0",
         "is-stream": "^3.0.0",
         "merge-stream": "^2.0.0",
         "npm-run-path": "^5.1.0",
         "onetime": "^6.0.0",
-        "signal-exit": "^4.1.0",
+        "signal-exit": "^3.0.7",
         "strip-final-newline": "^3.0.0"
       },
       "engines": {
-        "node": ">=16.17"
+        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/env-ci/node_modules/get-stream": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/env-ci/node_modules/human-signals": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+      "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
       "dev": true,
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/env-ci/node_modules/is-stream": {
@@ -4907,18 +4978,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/env-ci/node_modules/strip-final-newline": {
@@ -5825,6 +5884,15 @@
         "uglify-js": "^3.1.4"
       }
     },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6117,6 +6185,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-plain-object": {
@@ -8152,6 +8229,15 @@
         "node": "*"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -8248,6 +8334,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
@@ -8270,6 +8362,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
     "node_modules/lodash.isplainobject": {
@@ -8339,10 +8437,22 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/marked": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.2.tgz",
-      "integrity": "sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
       "dev": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -8352,23 +8462,23 @@
       }
     },
     "node_modules/marked-terminal": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.0.0.tgz",
-      "integrity": "sha512-6rruICvqRfA4N+Mvdc0UyDbLA0A0nI5omtARIlin3P2F+aNc3EbW91Rd9HTuD0v9qWyHmNIu8Bt40gAnPfldsg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
+      "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
         "cardinal": "^2.1.1",
-        "chalk": "^5.3.0",
+        "chalk": "^5.2.0",
         "cli-table3": "^0.6.3",
-        "node-emoji": "^2.1.0",
-        "supports-hyperlinks": "^3.0.0"
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.3.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=14.13.1 || >=16.0.0"
       },
       "peerDependencies": {
-        "marked": ">=1 <10"
+        "marked": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/marked-terminal/node_modules/chalk": {
@@ -8383,47 +8493,185 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/marked-terminal/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/marked-terminal/node_modules/supports-hyperlinks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-      "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0",
-        "supports-color": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/meow/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "engines": {
-        "node": ">=16.10"
+        "node": ">=6"
+      }
+    },
+    "node_modules/meow/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/meow/node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/meow/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8481,6 +8729,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -8500,6 +8757,29 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ms": {
@@ -8527,15 +8807,12 @@
       "dev": true
     },
     "node_modules/node-emoji": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.0.tgz",
-      "integrity": "sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "dependencies": {
-        "@sindresorhus/is": "^3.1.2",
-        "char-regex": "^1.0.2",
-        "emojilib": "^2.4.0",
-        "skin-tone": "^2.0.0"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/node-int64": {
@@ -8551,18 +8828,30 @@
       "dev": true
     },
     "node_modules/normalize-package-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
@@ -8602,9 +8891,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.1.tgz",
-      "integrity": "sha512-YVh8UDw5lR2bPS6rrS0aPG9ZXKDWeaeO/zMoZMp7g3Thrho9cqEnSrcvg4Pic2QhDAQptAynx5KgrPgCSRscqg==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.0.tgz",
+      "integrity": "sha512-wkd7sjz4KmdmddYQcd0aTP73P1cEuPlekeulz4jTDeMVx/Zo5XZ5KQ1z3eUzV3Q/WZpEO0NJXTrD5FNFe6fhCA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -8614,7 +8903,6 @@
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
         "@npmcli/run-script",
-        "@sigstore/tuf",
         "abbrev",
         "archy",
         "cacache",
@@ -8666,9 +8954,9 @@
         "qrcode-terminal",
         "read",
         "semver",
+        "sigstore",
         "spdx-expression-parse",
         "ssri",
-        "strip-ansi",
         "supports-color",
         "tar",
         "text-table",
@@ -8681,75 +8969,74 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.0",
-        "@npmcli/config": "^8.0.1",
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/config": "^6.4.0",
         "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.1",
-        "@sigstore/tuf": "^2.1.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.0",
+        "cacache": "^17.1.3",
         "chalk": "^5.3.0",
-        "ci-info": "^3.9.0",
+        "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "fs-minipass": "^3.0.2",
+        "glob": "^10.2.7",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
+        "hosted-git-info": "^6.1.1",
         "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
+        "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.2",
-        "libnpmexec": "^7.0.2",
-        "libnpmfund": "^5.0.0",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.2",
-        "libnpmpublish": "^9.0.1",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.0",
-        "make-fetch-happen": "^13.0.0",
+        "libnpmaccess": "^7.0.2",
+        "libnpmdiff": "^5.0.20",
+        "libnpmexec": "^6.0.4",
+        "libnpmfund": "^4.2.1",
+        "libnpmhook": "^9.0.3",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.20",
+        "libnpmpublish": "^7.5.0",
+        "libnpmsearch": "^6.0.2",
+        "libnpmteam": "^5.0.3",
+        "libnpmversion": "^4.0.2",
+        "make-fetch-happen": "^11.1.1",
         "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
         "node-gyp": "^9.4.0",
         "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
+        "normalize-package-data": "^5.0.0",
         "npm-audit-report": "^5.0.0",
-        "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
+        "npm-install-checks": "^6.2.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.2",
+        "npm-profile": "^7.0.1",
+        "npm-registry-fetch": "^14.0.5",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.4",
+        "pacote": "^15.2.0",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
         "semver": "^7.5.4",
+        "sigstore": "^1.9.0",
         "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
-        "strip-ansi": "^6.0.1",
+        "ssri": "^10.0.4",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
         "validate-npm-package-name": "^5.0.0",
-        "which": "^4.0.0",
+        "which": "^3.0.1",
         "write-file-atomic": "^5.0.1"
       },
       "bin": {
@@ -8757,7 +9044,7 @@
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -8855,76 +9142,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/agent-base": {
-      "version": "7.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "^4.3.4",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.2.0",
+      "version": "6.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8933,33 +9152,33 @@
         "@npmcli/fs": "^3.1.0",
         "@npmcli/installed-package-contents": "^2.0.2",
         "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/metavuln-calculator": "^7.0.0",
+        "@npmcli/metavuln-calculator": "^5.0.0",
         "@npmcli/name-from-folder": "^2.0.0",
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/query": "^3.0.1",
-        "@npmcli/run-script": "^7.0.1",
+        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/query": "^3.0.0",
+        "@npmcli/run-script": "^6.0.0",
         "bin-links": "^4.0.1",
-        "cacache": "^18.0.0",
+        "cacache": "^17.0.4",
         "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^7.0.1",
+        "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
         "json-stringify-nice": "^1.1.4",
         "minimatch": "^9.0.0",
         "nopt": "^7.0.0",
         "npm-install-checks": "^6.2.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.1",
+        "npm-registry-fetch": "^14.0.3",
         "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
+        "pacote": "^15.0.8",
         "parse-conflict-json": "^3.0.0",
         "proc-log": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.2",
         "read-package-json-fast": "^3.0.2",
         "semver": "^7.3.7",
-        "ssri": "^10.0.5",
+        "ssri": "^10.0.1",
         "treeverse": "^3.0.0",
         "walk-up-path": "^3.0.1"
       },
@@ -8967,11 +9186,11 @@
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.0.1",
+      "version": "6.4.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8986,7 +9205,7 @@
         "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
@@ -9014,22 +9233,22 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "5.0.3",
+      "version": "4.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^7.0.0",
-        "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^9.0.0",
+        "@npmcli/promise-spawn": "^6.0.0",
+        "lru-cache": "^7.4.4",
+        "npm-pick-manifest": "^8.0.0",
         "proc-log": "^3.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^4.0.0"
+        "which": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
@@ -9064,18 +9283,18 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "7.0.0",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^18.0.0",
+        "cacache": "^17.0.0",
         "json-parse-even-better-errors": "^3.0.0",
-        "pacote": "^17.0.0",
+        "pacote": "^15.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
@@ -9097,37 +9316,37 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "5.0.0",
+      "version": "4.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
+        "@npmcli/git": "^4.1.0",
         "glob": "^10.2.2",
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
+        "normalize-package-data": "^5.0.0",
         "proc-log": "^3.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^4.0.0"
+        "which": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "3.0.1",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9139,19 +9358,19 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "7.0.1",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
+        "@npmcli/promise-spawn": "^6.0.0",
         "node-gyp": "^9.0.0",
         "read-package-json-fast": "^3.0.0",
-        "which": "^4.0.0"
+        "which": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
@@ -9165,15 +9384,15 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
+      "version": "1.1.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1"
+        "@sigstore/protobuf-specs": "^0.2.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
@@ -9186,30 +9405,30 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.1.0",
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "make-fetch-happen": "^13.0.0"
+        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "make-fetch-happen": "^11.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.1.0",
+      "version": "1.0.3",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "tuf-js": "^1.1.7"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
@@ -9222,25 +9441,25 @@
       }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
-      "version": "2.0.0",
+      "version": "1.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "2.0.0",
+      "version": "1.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
+        "@tufjs/canonical-json": "1.0.0",
+        "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/abbrev": {
@@ -9277,11 +9496,13 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.5.0",
+      "version": "4.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.1.0",
+        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -9338,7 +9559,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9377,7 +9598,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.3",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9443,7 +9664,7 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.0",
+      "version": "17.1.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9451,8 +9672,8 @@
         "@npmcli/fs": "^3.1.0",
         "fs-minipass": "^3.0.0",
         "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
+        "lru-cache": "^7.7.1",
+        "minipass": "^5.0.0",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
@@ -9462,7 +9683,7 @@
         "unique-filename": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
@@ -9487,7 +9708,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "3.9.0",
+      "version": "3.8.0",
       "dev": true,
       "funding": [
         {
@@ -9560,7 +9781,7 @@
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "6.0.2",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9708,6 +9929,15 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/depd": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/npm/node_modules/diff": {
       "version": "5.1.0",
       "dev": true,
@@ -9804,12 +10034,12 @@
       }
     },
     "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.3",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.3"
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9847,19 +10077,19 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
+        "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
       },
       "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "glob": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9893,15 +10123,15 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "7.0.1",
+      "version": "6.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "lru-cache": "^10.0.1"
+        "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -10035,21 +10265,21 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "6.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^11.0.0",
+        "npm-package-arg": "^10.0.0",
         "promzard": "^1.0.0",
         "read": "^2.0.0",
-        "read-package-json": "^7.0.0",
+        "read-package-json": "^6.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/ip": {
@@ -10080,7 +10310,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.13.0",
+      "version": "2.12.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10113,7 +10343,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.3.6",
+      "version": "2.2.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -10170,50 +10400,50 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^7.2.0",
-        "@npmcli/disparity-colors": "^3.0.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4",
-        "tar": "^6.2.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
       "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.0",
-        "@npmcli/run-script": "^7.0.1",
+        "npm-package-arg": "^10.1.0",
+        "npm-registry-fetch": "^14.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "5.0.20",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/disparity-colors": "^3.0.0",
+        "@npmcli/installed-package-contents": "^2.0.2",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.1.0",
+        "minimatch": "^9.0.0",
+        "npm-package-arg": "^10.1.0",
+        "pacote": "^15.0.8",
+        "tar": "^6.1.13"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "6.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/run-script": "^6.0.0",
         "ci-info": "^3.7.1",
-        "npm-package-arg": "^11.0.1",
+        "npm-package-arg": "^10.1.0",
         "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
+        "pacote": "^15.0.8",
         "proc-log": "^3.0.0",
         "read": "^2.0.0",
         "read-package-json-fast": "^3.0.2",
@@ -10221,151 +10451,155 @@
         "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.0",
+      "version": "4.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.0"
+        "@npmcli/arborist": "^6.5.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
-      "version": "10.0.0",
+      "version": "9.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.1",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.2",
+      "version": "5.0.20",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.0",
-        "@npmcli/run-script": "^7.0.1",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4"
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/run-script": "^6.0.0",
+        "npm-package-arg": "^10.1.0",
+        "pacote": "^15.0.8"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.1",
+      "version": "7.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "ci-info": "^3.6.1",
-        "normalize-package-data": "^6.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-registry-fetch": "^14.0.3",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^2.1.0",
-        "ssri": "^10.0.5"
+        "sigstore": "^1.4.0",
+        "ssri": "^10.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.0",
+      "version": "6.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.0",
+      "version": "5.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^14.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.0",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.3",
-        "@npmcli/run-script": "^7.0.1",
+        "@npmcli/git": "^4.0.1",
+        "@npmcli/run-script": "^6.0.0",
         "json-parse-even-better-errors": "^3.0.0",
         "proc-log": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.0.1",
+      "version": "7.18.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "14 || >=16.14"
+        "node": ">=12"
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "13.0.0",
+      "version": "11.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^17.0.0",
         "http-cache-semantics": "^4.1.1",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
-        "minipass": "^7.0.2",
+        "lru-cache": "^7.7.1",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
         "ssri": "^10.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
@@ -10384,12 +10618,12 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.0.4",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minipass-collect": {
@@ -10417,12 +10651,12 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.4",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.3",
+        "minipass": "^5.0.0",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
       },
@@ -10642,84 +10876,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache": {
-      "version": "17.1.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^7.7.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^1.0.2",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/glob": {
-      "version": "10.3.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/cacache/node_modules/minipass": {
-      "version": "7.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
       "dev": true,
@@ -10759,41 +10915,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/lru-cache": {
-      "version": "7.18.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/make-fetch-happen": {
-      "version": "11.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "agentkeepalive": "^4.2.1",
-        "cacache": "^17.0.0",
-        "http-cache-semantics": "^4.1.1",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "is-lambda": "^1.0.1",
-        "lru-cache": "^7.7.1",
-        "minipass": "^5.0.0",
-        "minipass-fetch": "^3.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^7.0.0",
-        "ssri": "^10.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/node-gyp/node_modules/minimatch": {
       "version": "3.1.2",
       "dev": true,
@@ -10804,15 +10925,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
@@ -10896,18 +11008,18 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "6.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^6.0.0",
         "is-core-module": "^2.8.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
@@ -10932,7 +11044,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "6.3.0",
+      "version": "6.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -10953,22 +11065,22 @@
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "11.0.1",
+      "version": "10.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
+        "hosted-git-info": "^6.0.0",
         "proc-log": "^3.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "8.0.0",
+      "version": "7.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10980,49 +11092,49 @@
       }
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^6.0.0",
         "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
+        "npm-package-arg": "^10.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "9.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0",
+        "npm-registry-fetch": "^14.0.0",
         "proc-log": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "16.1.0",
+      "version": "14.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "make-fetch-happen": "^13.0.0",
-        "minipass": "^7.0.2",
+        "make-fetch-happen": "^11.0.0",
+        "minipass": "^5.0.0",
         "minipass-fetch": "^3.0.0",
         "minipass-json-stream": "^1.0.1",
         "minizlib": "^2.1.2",
-        "npm-package-arg": "^11.0.0",
+        "npm-package-arg": "^10.0.0",
         "proc-log": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
@@ -11074,27 +11186,27 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.4",
+      "version": "15.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
+        "@npmcli/git": "^4.0.0",
         "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/promise-spawn": "^6.0.1",
+        "@npmcli/run-script": "^6.0.0",
+        "cacache": "^17.0.0",
         "fs-minipass": "^3.0.0",
-        "minipass": "^7.0.2",
-        "npm-package-arg": "^11.0.0",
-        "npm-packlist": "^8.0.0",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
+        "minipass": "^5.0.0",
+        "npm-package-arg": "^10.0.0",
+        "npm-packlist": "^7.0.0",
+        "npm-pick-manifest": "^8.0.0",
+        "npm-registry-fetch": "^14.0.0",
         "proc-log": "^3.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^7.0.0",
+        "read-package-json": "^6.0.0",
         "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
+        "sigstore": "^1.3.0",
         "ssri": "^10.0.0",
         "tar": "^6.1.11"
       },
@@ -11102,7 +11214,7 @@
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
@@ -11138,19 +11250,28 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.9.2",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+        "lru-cache": "^9.1.1",
+        "minipass": "^5.0.0 || ^6.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "9.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
@@ -11263,18 +11384,18 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "7.0.0",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^10.2.2",
         "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
+        "normalize-package-data": "^5.0.0",
         "npm-normalize-package-bin": "^3.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
@@ -11291,7 +11412,7 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.4.2",
+      "version": "4.4.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -11299,8 +11420,7 @@
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
+        "process": "^0.11.10"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -11466,18 +11586,22 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.1.0",
+      "version": "1.9.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/bundle": "^1.1.0",
+        "@sigstore/protobuf-specs": "^0.2.0",
+        "@sigstore/sign": "^1.0.0",
+        "@sigstore/tuf": "^1.0.3",
+        "make-fetch-happen": "^11.0.1"
+      },
+      "bin": {
+        "sigstore": "bin/sigstore.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
@@ -11545,18 +11669,18 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.16",
+      "version": "3.0.13",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.5",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^7.0.3"
+        "minipass": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11638,7 +11762,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.1.15",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -11678,15 +11802,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
       "dev": true,
@@ -11709,17 +11824,17 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.1.0",
+      "version": "1.1.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.0",
+        "@tufjs/models": "1.0.4",
         "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.0"
+        "make-fetch-happen": "^11.1.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
@@ -11790,27 +11905,18 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "4.0.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "isexe": "^3.1.1"
+        "isexe": "^2.0.0"
       },
       "bin": {
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/which/node_modules/isexe": {
-      "version": "3.1.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/wide-align": {
@@ -12432,6 +12538,15 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -12588,6 +12703,21 @@
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
     "node_modules/read-pkg/node_modules/parse-json": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
@@ -12619,6 +12749,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.5.0.tgz",
@@ -12644,6 +12789,28 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/redeyed": {
@@ -12854,20 +13021,20 @@
       "dev": true
     },
     "node_modules/semantic-release": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.5.tgz",
-      "integrity": "sha512-ESCEQsZlBj1DWMA84RthaJzQHHnihoGk49s9nUxHfRNUNZelLE9JZrE94bHO2Y00EWb7iwrzr1OYhv5QNVmf8A==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.2.tgz",
+      "integrity": "sha512-kz76azHrT8+VEkQjoCBHE06JNQgTgsC4bT8XfCzb7DHcsk9vG3fqeMVik8h5rcWCYi2Fd+M3bwA7BG8Z8cRwtA==",
       "dev": true,
       "dependencies": {
-        "@semantic-release/commit-analyzer": "^11.0.0",
+        "@semantic-release/commit-analyzer": "^10.0.0",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^9.0.0",
-        "@semantic-release/npm": "^11.0.0",
-        "@semantic-release/release-notes-generator": "^12.0.0",
+        "@semantic-release/npm": "^10.0.2",
+        "@semantic-release/release-notes-generator": "^11.0.0",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^8.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^10.0.0",
+        "env-ci": "^9.0.0",
         "execa": "^8.0.0",
         "figures": "^5.0.0",
         "find-versions": "^5.1.0",
@@ -12876,8 +13043,8 @@
         "hook-std": "^3.0.0",
         "hosted-git-info": "^7.0.0",
         "lodash-es": "^4.17.21",
-        "marked": "^9.0.0",
-        "marked-terminal": "^6.0.0",
+        "marked": "^5.0.0",
+        "marked-terminal": "^5.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
@@ -12892,7 +13059,7 @@
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": "^18.17 || >=20.6.1"
+        "node": ">=18"
       }
     },
     "node_modules/semantic-release/node_modules/escape-string-regexp": {
@@ -13152,18 +13319,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "node_modules/skin-tone": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
-      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-      "dev": true,
-      "dependencies": {
-        "unicode-emoji-modifier-base": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -13229,6 +13384,18 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
       "dev": true
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -13342,6 +13509,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -13361,6 +13540,40 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/temp-dir": {
@@ -13485,6 +13698,15 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -13570,15 +13792,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
       "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/unicode-emoji-modifier-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
-      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -13862,6 +14075,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yargs/node_modules/yargs-parser": {
@@ -16093,13 +16315,13 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.0.0.tgz",
-      "integrity": "sha512-uEXyf4Z0AWJuxI9TbSQP5kkIYqus1/E1NcmE7pIv6d6/m/5EJcNWAGR4FOo34vrV26FhEaRVkxFfYzp/M7BKIg==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.4.tgz",
+      "integrity": "sha512-pFGn99fn8w4/MHE0otb2A/l5kxgOuxaaauIh4u30ncoTJuqWj4hXTgEJ03REqjS+w1R2vPftSsO26WC61yOcpw==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-commits-filter": "^4.0.0",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-commits-filter": "^3.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
@@ -16159,9 +16381,9 @@
       }
     },
     "@semantic-release/npm": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.0.tgz",
-      "integrity": "sha512-ozNCiPUp14Xp2rgeY7j96yFTEhDncLSWOJr0IAUr888+ax6fH5xgYkNVv08vpkV8C5GIXBgnGd9coRiOCD6oqQ==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-10.0.6.tgz",
+      "integrity": "sha512-DyqHrGE8aUyapA277BB+4kV0C4iMHh3sHzUWdf0jTgp5NNJxVUz76W1f57FB64Ue03him3CBXxFqQD2xGabxow==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^4.0.0",
@@ -16171,7 +16393,7 @@
         "lodash-es": "^4.17.21",
         "nerf-dart": "^1.0.0",
         "normalize-url": "^8.0.0",
-        "npm": "^10.0.0",
+        "npm": "^9.5.0",
         "rc": "^1.2.8",
         "read-pkg": "^8.0.0",
         "registry-auth-token": "^5.0.0",
@@ -16253,13 +16475,13 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.0.0.tgz",
-      "integrity": "sha512-m7Ds8ComP1KJgA2Lke2xMwE1TOOU40U7AzP4lT8hJ2tUAeicziPz/1GeDFmRkTOkMFlfHvE6kuvMkvU+mIzIDQ==",
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-11.0.7.tgz",
+      "integrity": "sha512-T09QB9ImmNx7Q6hY6YnnEbw/rEJ6a+22LBxfZq+pSAXg/OL/k0siwEm5cK4k1f9dE2Z2mPIjJKKohzUm0jbxcQ==",
       "dev": true,
       "requires": {
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-changelog-writer": "^7.0.0",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-changelog-writer": "^6.0.0",
         "conventional-commits-filter": "^4.0.0",
         "conventional-commits-parser": "^5.0.0",
         "debug": "^4.0.0",
@@ -16270,6 +16492,12 @@
         "read-pkg-up": "^10.0.0"
       },
       "dependencies": {
+        "conventional-commits-filter": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+          "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+          "dev": true
+        },
         "get-stream": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
@@ -16282,12 +16510,6 @@
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
       "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
-      "dev": true
-    },
-    "@sindresorhus/is": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-      "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -16386,6 +16608,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/minimist": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.4.tgz",
+      "integrity": "sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==",
       "dev": true
     },
     "@types/node": {
@@ -16620,6 +16848,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
     "babel-core": {
@@ -16862,6 +17096,17 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001551",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
@@ -17051,26 +17296,27 @@
       }
     },
     "conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"
       }
     },
     "conventional-changelog-writer": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
-      "integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-6.0.1.tgz",
+      "integrity": "sha512-359t9aHorPw+U+nHzUXHS5ZnPBOizRxfQsWT5ZDHBfvfxQOAik+yfuhKXG66CN5LEWPpMNnIMHUTCKeYNprvHQ==",
       "dev": true,
       "requires": {
-        "conventional-commits-filter": "^4.0.0",
+        "conventional-commits-filter": "^3.0.0",
+        "dateformat": "^3.0.3",
         "handlebars": "^4.7.7",
         "json-stringify-safe": "^5.0.1",
-        "meow": "^12.0.1",
-        "semver": "^7.5.2",
-        "split2": "^4.0.0"
+        "meow": "^8.1.2",
+        "semver": "^7.0.0",
+        "split": "^1.0.1"
       },
       "dependencies": {
         "semver": {
@@ -17085,10 +17331,14 @@
       }
     },
     "conventional-commits-filter": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
-      "integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+      "dev": true,
+      "requires": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.1"
+      }
     },
     "conventional-commits-parser": {
       "version": "5.0.0",
@@ -17100,6 +17350,14 @@
         "JSONStream": "^1.3.5",
         "meow": "^12.0.1",
         "split2": "^4.0.0"
+      },
+      "dependencies": {
+        "meow": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+          "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+          "dev": true
+        }
       }
     },
     "convert-source-map": {
@@ -17246,6 +17504,12 @@
         }
       }
     },
+    "dateformat": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -17253,6 +17517,30 @@
       "dev": true,
       "requires": {
         "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
       }
     },
     "dedent": {
@@ -17352,49 +17640,37 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
-    "emojilib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
-      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-      "dev": true
-    },
     "env-ci": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-10.0.0.tgz",
-      "integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-9.1.1.tgz",
+      "integrity": "sha512-Im2yEWeF4b2RAMAaWvGioXk6m0UNaIjD8hj28j2ij5ldnIFrDQT0+pzDvpbRkcjurhXhf/AsBKv8P2rtmGi9Aw==",
       "dev": true,
       "requires": {
-        "execa": "^8.0.0",
+        "execa": "^7.0.0",
         "java-properties": "^1.0.2"
       },
       "dependencies": {
         "execa": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
-          "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-7.2.0.tgz",
+          "integrity": "sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.3",
-            "get-stream": "^8.0.1",
-            "human-signals": "^5.0.0",
+            "get-stream": "^6.0.1",
+            "human-signals": "^4.3.0",
             "is-stream": "^3.0.0",
             "merge-stream": "^2.0.0",
             "npm-run-path": "^5.1.0",
             "onetime": "^6.0.0",
-            "signal-exit": "^4.1.0",
+            "signal-exit": "^3.0.7",
             "strip-final-newline": "^3.0.0"
           }
         },
-        "get-stream": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
-          "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
-          "dev": true
-        },
         "human-signals": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
-          "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+          "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
           "dev": true
         },
         "is-stream": {
@@ -17416,12 +17692,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
           "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
           "dev": true
         },
         "strip-final-newline": {
@@ -18077,6 +18347,12 @@
         "wordwrap": "^1.0.0"
       }
     },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -18281,6 +18557,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-plain-object": {
@@ -19762,6 +20044,12 @@
         "through": ">=2.2.7 <3"
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -19836,6 +20124,12 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
@@ -19858,6 +20152,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
     "lodash.isplainobject": {
@@ -19920,24 +20220,30 @@
         "tmpl": "1.0.5"
       }
     },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
     "marked": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-9.1.2.tgz",
-      "integrity": "sha512-qoKMJqK0w6vkLk8+KnKZAH6neUZSNaQqVZ/h2yZ9S7CbLuFHyS2viB0jnqcWF9UKjwsAbMrQtnQhdmdvOVOw9w==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz",
+      "integrity": "sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==",
       "dev": true
     },
     "marked-terminal": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.0.0.tgz",
-      "integrity": "sha512-6rruICvqRfA4N+Mvdc0UyDbLA0A0nI5omtARIlin3P2F+aNc3EbW91Rd9HTuD0v9qWyHmNIu8Bt40gAnPfldsg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.2.0.tgz",
+      "integrity": "sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^6.2.0",
         "cardinal": "^2.1.1",
-        "chalk": "^5.3.0",
+        "chalk": "^5.2.0",
         "cli-table3": "^0.6.3",
-        "node-emoji": "^2.1.0",
-        "supports-hyperlinks": "^3.0.0"
+        "node-emoji": "^1.11.0",
+        "supports-hyperlinks": "^2.3.0"
       },
       "dependencies": {
         "chalk": {
@@ -19945,39 +20251,147 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
           "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
           "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "supports-hyperlinks": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
-          "integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0",
-            "supports-color": "^7.0.0"
-          }
         }
       }
     },
     "meow": {
-      "version": "12.1.1",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
-      "integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
-      "dev": true
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-8.1.2.tgz",
+      "integrity": "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "normalize-package-data": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+              "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+              "dev": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
+            }
+          }
+        },
+        "semver": {
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        }
+      }
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -20013,6 +20427,12 @@
       "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -20026,6 +20446,23 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      }
+    },
+    "modify-values": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
+      "integrity": "sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==",
       "dev": true
     },
     "ms": {
@@ -20053,15 +20490,12 @@
       "dev": true
     },
     "node-emoji": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.0.tgz",
-      "integrity": "sha512-tcsBm9C6FmPN5Wo7OjFi9lgMyJjvkAeirmjR/ax8Ttfqy4N8PoFic26uqFTIgayHPNI5FH4ltUvfh9kHzwcK9A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^3.1.2",
-        "char-regex": "^1.0.2",
-        "emojilib": "^2.4.0",
-        "skin-tone": "^2.0.0"
+        "lodash": "^4.17.21"
       }
     },
     "node-int64": {
@@ -20077,17 +20511,26 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
-      "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
         "semver": {
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -20112,81 +20555,80 @@
       "dev": true
     },
     "npm": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.1.tgz",
-      "integrity": "sha512-YVh8UDw5lR2bPS6rrS0aPG9ZXKDWeaeO/zMoZMp7g3Thrho9cqEnSrcvg4Pic2QhDAQptAynx5KgrPgCSRscqg==",
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.9.0.tgz",
+      "integrity": "sha512-wkd7sjz4KmdmddYQcd0aTP73P1cEuPlekeulz4jTDeMVx/Zo5XZ5KQ1z3eUzV3Q/WZpEO0NJXTrD5FNFe6fhCA==",
       "dev": true,
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.0",
-        "@npmcli/config": "^8.0.1",
+        "@npmcli/arborist": "^6.5.0",
+        "@npmcli/config": "^6.4.0",
         "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.1",
-        "@sigstore/tuf": "^2.1.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
+        "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.0",
+        "cacache": "^17.1.3",
         "chalk": "^5.3.0",
-        "ci-info": "^3.9.0",
+        "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
         "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "fs-minipass": "^3.0.2",
+        "glob": "^10.2.7",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
+        "hosted-git-info": "^6.1.1",
         "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
+        "init-package-json": "^5.0.0",
         "is-cidr": "^4.0.2",
         "json-parse-even-better-errors": "^3.0.0",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.2",
-        "libnpmexec": "^7.0.2",
-        "libnpmfund": "^5.0.0",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.2",
-        "libnpmpublish": "^9.0.1",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.0",
-        "make-fetch-happen": "^13.0.0",
+        "libnpmaccess": "^7.0.2",
+        "libnpmdiff": "^5.0.20",
+        "libnpmexec": "^6.0.4",
+        "libnpmfund": "^4.2.1",
+        "libnpmhook": "^9.0.3",
+        "libnpmorg": "^5.0.4",
+        "libnpmpack": "^5.0.20",
+        "libnpmpublish": "^7.5.0",
+        "libnpmsearch": "^6.0.2",
+        "libnpmteam": "^5.0.3",
+        "libnpmversion": "^4.0.2",
+        "make-fetch-happen": "^11.1.1",
         "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
         "node-gyp": "^9.4.0",
         "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
+        "normalize-package-data": "^5.0.0",
         "npm-audit-report": "^5.0.0",
-        "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
+        "npm-install-checks": "^6.2.0",
+        "npm-package-arg": "^10.1.0",
+        "npm-pick-manifest": "^8.0.2",
+        "npm-profile": "^7.0.1",
+        "npm-registry-fetch": "^14.0.5",
         "npm-user-validate": "^2.0.0",
         "npmlog": "^7.0.1",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.4",
+        "pacote": "^15.2.0",
         "parse-conflict-json": "^3.0.1",
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
         "semver": "^7.5.4",
+        "sigstore": "^1.9.0",
         "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
-        "strip-ansi": "^6.0.1",
+        "ssri": "^10.0.4",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
         "validate-npm-package-name": "^5.0.0",
-        "which": "^4.0.0",
+        "which": "^3.0.1",
         "write-file-atomic": "^5.0.1"
       },
       "dependencies": {
@@ -20244,58 +20686,8 @@
           "bundled": true,
           "dev": true
         },
-        "@npmcli/agent": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "agent-base": "^7.1.0",
-            "http-proxy-agent": "^7.0.0",
-            "https-proxy-agent": "^7.0.1",
-            "lru-cache": "^10.0.1",
-            "socks-proxy-agent": "^8.0.1"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "7.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "debug": "^4.3.4"
-              }
-            },
-            "http-proxy-agent": {
-              "version": "7.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "^7.1.0",
-                "debug": "^4.3.4"
-              }
-            },
-            "https-proxy-agent": {
-              "version": "7.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "^7.0.2",
-                "debug": "4"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "8.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agent-base": "^7.0.2",
-                "debug": "^4.3.4",
-                "socks": "^2.7.1"
-              }
-            }
-          }
-        },
         "@npmcli/arborist": {
-          "version": "7.2.0",
+          "version": "6.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20303,39 +20695,39 @@
             "@npmcli/fs": "^3.1.0",
             "@npmcli/installed-package-contents": "^2.0.2",
             "@npmcli/map-workspaces": "^3.0.2",
-            "@npmcli/metavuln-calculator": "^7.0.0",
+            "@npmcli/metavuln-calculator": "^5.0.0",
             "@npmcli/name-from-folder": "^2.0.0",
             "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/package-json": "^5.0.0",
-            "@npmcli/query": "^3.0.1",
-            "@npmcli/run-script": "^7.0.1",
+            "@npmcli/package-json": "^4.0.0",
+            "@npmcli/query": "^3.0.0",
+            "@npmcli/run-script": "^6.0.0",
             "bin-links": "^4.0.1",
-            "cacache": "^18.0.0",
+            "cacache": "^17.0.4",
             "common-ancestor-path": "^1.0.1",
-            "hosted-git-info": "^7.0.1",
+            "hosted-git-info": "^6.1.1",
             "json-parse-even-better-errors": "^3.0.0",
             "json-stringify-nice": "^1.1.4",
             "minimatch": "^9.0.0",
             "nopt": "^7.0.0",
             "npm-install-checks": "^6.2.0",
-            "npm-package-arg": "^11.0.1",
-            "npm-pick-manifest": "^9.0.0",
-            "npm-registry-fetch": "^16.0.0",
+            "npm-package-arg": "^10.1.0",
+            "npm-pick-manifest": "^8.0.1",
+            "npm-registry-fetch": "^14.0.3",
             "npmlog": "^7.0.1",
-            "pacote": "^17.0.4",
+            "pacote": "^15.0.8",
             "parse-conflict-json": "^3.0.0",
             "proc-log": "^3.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.2",
             "read-package-json-fast": "^3.0.2",
             "semver": "^7.3.7",
-            "ssri": "^10.0.5",
+            "ssri": "^10.0.1",
             "treeverse": "^3.0.0",
             "walk-up-path": "^3.0.1"
           }
         },
         "@npmcli/config": {
-          "version": "8.0.1",
+          "version": "6.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20366,18 +20758,18 @@
           }
         },
         "@npmcli/git": {
-          "version": "5.0.3",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/promise-spawn": "^7.0.0",
-            "lru-cache": "^10.0.1",
-            "npm-pick-manifest": "^9.0.0",
+            "@npmcli/promise-spawn": "^6.0.0",
+            "lru-cache": "^7.4.4",
+            "npm-pick-manifest": "^8.0.0",
             "proc-log": "^3.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
-            "which": "^4.0.0"
+            "which": "^3.0.0"
           }
         },
         "@npmcli/installed-package-contents": {
@@ -20401,13 +20793,13 @@
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "7.0.0",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "cacache": "^18.0.0",
+            "cacache": "^17.0.0",
             "json-parse-even-better-errors": "^3.0.0",
-            "pacote": "^17.0.0",
+            "pacote": "^15.0.0",
             "semver": "^7.3.5"
           }
         },
@@ -20422,29 +20814,29 @@
           "dev": true
         },
         "@npmcli/package-json": {
-          "version": "5.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^5.0.0",
+            "@npmcli/git": "^4.1.0",
             "glob": "^10.2.2",
-            "hosted-git-info": "^7.0.0",
+            "hosted-git-info": "^6.1.1",
             "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^6.0.0",
+            "normalize-package-data": "^5.0.0",
             "proc-log": "^3.0.0",
             "semver": "^7.5.3"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "7.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "which": "^4.0.0"
+            "which": "^3.0.0"
           }
         },
         "@npmcli/query": {
-          "version": "3.0.1",
+          "version": "3.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20452,15 +20844,15 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "7.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/promise-spawn": "^7.0.0",
+            "@npmcli/promise-spawn": "^6.0.0",
             "node-gyp": "^9.0.0",
             "read-package-json-fast": "^3.0.0",
-            "which": "^4.0.0"
+            "which": "^3.0.0"
           }
         },
         "@pkgjs/parseargs": {
@@ -20470,11 +20862,11 @@
           "optional": true
         },
         "@sigstore/bundle": {
-          "version": "2.1.0",
+          "version": "1.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/protobuf-specs": "^0.2.1"
+            "@sigstore/protobuf-specs": "^0.2.0"
           }
         },
         "@sigstore/protobuf-specs": {
@@ -20483,22 +20875,22 @@
           "dev": true
         },
         "@sigstore/sign": {
-          "version": "2.1.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^2.1.0",
-            "@sigstore/protobuf-specs": "^0.2.1",
-            "make-fetch-happen": "^13.0.0"
+            "@sigstore/bundle": "^1.1.0",
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "make-fetch-happen": "^11.0.1"
           }
         },
         "@sigstore/tuf": {
-          "version": "2.1.0",
+          "version": "1.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/protobuf-specs": "^0.2.1",
-            "tuf-js": "^2.1.0"
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "tuf-js": "^1.1.7"
           }
         },
         "@tootallnate/once": {
@@ -20507,17 +20899,17 @@
           "dev": true
         },
         "@tufjs/canonical-json": {
-          "version": "2.0.0",
+          "version": "1.0.0",
           "bundled": true,
           "dev": true
         },
         "@tufjs/models": {
-          "version": "2.0.0",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tufjs/canonical-json": "2.0.0",
-            "minimatch": "^9.0.3"
+            "@tufjs/canonical-json": "1.0.0",
+            "minimatch": "^9.0.0"
           }
         },
         "abbrev": {
@@ -20542,10 +20934,12 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.5.0",
+          "version": "4.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "debug": "^4.1.0",
+            "depd": "^2.0.0",
             "humanize-ms": "^1.2.1"
           }
         },
@@ -20582,7 +20976,7 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "4.0.1",
+          "version": "4.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20601,7 +20995,7 @@
           "dev": true
         },
         "bin-links": {
-          "version": "4.0.3",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -20642,15 +21036,15 @@
           }
         },
         "cacache": {
-          "version": "18.0.0",
+          "version": "17.1.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/fs": "^3.1.0",
             "fs-minipass": "^3.0.0",
             "glob": "^10.2.2",
-            "lru-cache": "^10.0.1",
-            "minipass": "^7.0.3",
+            "lru-cache": "^7.7.1",
+            "minipass": "^5.0.0",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
@@ -20671,7 +21065,7 @@
           "dev": true
         },
         "ci-info": {
-          "version": "3.9.0",
+          "version": "3.8.0",
           "bundled": true,
           "dev": true
         },
@@ -20712,7 +21106,7 @@
           "dev": true
         },
         "cmd-shim": {
-          "version": "6.0.2",
+          "version": "6.0.1",
           "bundled": true,
           "dev": true
         },
@@ -20811,6 +21205,11 @@
           "bundled": true,
           "dev": true
         },
+        "depd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true
+        },
         "diff": {
           "version": "5.1.0",
           "bundled": true,
@@ -20875,11 +21274,11 @@
           }
         },
         "fs-minipass": {
-          "version": "3.0.3",
+          "version": "3.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^7.0.3"
+            "minipass": "^5.0.0"
           }
         },
         "fs.realpath": {
@@ -20908,15 +21307,15 @@
           }
         },
         "glob": {
-          "version": "10.3.10",
+          "version": "10.2.7",
           "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "^3.1.0",
-            "jackspeak": "^2.3.5",
+            "jackspeak": "^2.0.3",
             "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-            "path-scurry": "^1.10.1"
+            "minipass": "^5.0.0 || ^6.0.2",
+            "path-scurry": "^1.7.0"
           }
         },
         "graceful-fs": {
@@ -20938,11 +21337,11 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "7.0.1",
+          "version": "6.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^10.0.1"
+            "lru-cache": "^7.5.1"
           }
         },
         "http-cache-semantics": {
@@ -21029,14 +21428,14 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "6.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^11.0.0",
+            "npm-package-arg": "^10.0.0",
             "promzard": "^1.0.0",
             "read": "^2.0.0",
-            "read-package-json": "^7.0.0",
+            "read-package-json": "^6.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^5.0.0"
@@ -21061,7 +21460,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.13.0",
+          "version": "2.12.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21084,7 +21483,7 @@
           "dev": true
         },
         "jackspeak": {
-          "version": "2.3.6",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21118,41 +21517,41 @@
           "dev": true
         },
         "libnpmaccess": {
-          "version": "8.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-package-arg": "^11.0.1",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-package-arg": "^10.1.0",
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmdiff": {
-          "version": "6.0.2",
+          "version": "5.0.20",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.0",
+            "@npmcli/arborist": "^6.5.0",
             "@npmcli/disparity-colors": "^3.0.0",
             "@npmcli/installed-package-contents": "^2.0.2",
             "binary-extensions": "^2.2.0",
             "diff": "^5.1.0",
             "minimatch": "^9.0.0",
-            "npm-package-arg": "^11.0.1",
-            "pacote": "^17.0.4",
-            "tar": "^6.2.0"
+            "npm-package-arg": "^10.1.0",
+            "pacote": "^15.0.8",
+            "tar": "^6.1.13"
           }
         },
         "libnpmexec": {
-          "version": "7.0.2",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.0",
-            "@npmcli/run-script": "^7.0.1",
+            "@npmcli/arborist": "^6.5.0",
+            "@npmcli/run-script": "^6.0.0",
             "ci-info": "^3.7.1",
-            "npm-package-arg": "^11.0.1",
+            "npm-package-arg": "^10.1.0",
             "npmlog": "^7.0.1",
-            "pacote": "^17.0.4",
+            "pacote": "^15.0.8",
             "proc-log": "^3.0.0",
             "read": "^2.0.0",
             "read-package-json-fast": "^3.0.2",
@@ -21161,106 +21560,110 @@
           }
         },
         "libnpmfund": {
-          "version": "5.0.0",
+          "version": "4.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.0"
+            "@npmcli/arborist": "^6.5.0"
           }
         },
         "libnpmhook": {
-          "version": "10.0.0",
+          "version": "9.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmorg": {
-          "version": "6.0.1",
+          "version": "5.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmpack": {
-          "version": "6.0.2",
+          "version": "5.0.20",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/arborist": "^7.2.0",
-            "@npmcli/run-script": "^7.0.1",
-            "npm-package-arg": "^11.0.1",
-            "pacote": "^17.0.4"
+            "@npmcli/arborist": "^6.5.0",
+            "@npmcli/run-script": "^6.0.0",
+            "npm-package-arg": "^10.1.0",
+            "pacote": "^15.0.8"
           }
         },
         "libnpmpublish": {
-          "version": "9.0.1",
+          "version": "7.5.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "ci-info": "^3.6.1",
-            "normalize-package-data": "^6.0.0",
-            "npm-package-arg": "^11.0.1",
-            "npm-registry-fetch": "^16.0.0",
+            "normalize-package-data": "^5.0.0",
+            "npm-package-arg": "^10.1.0",
+            "npm-registry-fetch": "^14.0.3",
             "proc-log": "^3.0.0",
             "semver": "^7.3.7",
-            "sigstore": "^2.1.0",
-            "ssri": "^10.0.5"
+            "sigstore": "^1.4.0",
+            "ssri": "^10.0.1"
           }
         },
         "libnpmsearch": {
-          "version": "7.0.0",
+          "version": "6.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmteam": {
-          "version": "6.0.0",
+          "version": "5.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^16.0.0"
+            "npm-registry-fetch": "^14.0.3"
           }
         },
         "libnpmversion": {
-          "version": "5.0.0",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^5.0.3",
-            "@npmcli/run-script": "^7.0.1",
+            "@npmcli/git": "^4.0.1",
+            "@npmcli/run-script": "^6.0.0",
             "json-parse-even-better-errors": "^3.0.0",
             "proc-log": "^3.0.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "10.0.1",
+          "version": "7.18.3",
           "bundled": true,
           "dev": true
         },
         "make-fetch-happen": {
-          "version": "13.0.0",
+          "version": "11.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/agent": "^2.0.0",
-            "cacache": "^18.0.0",
+            "agentkeepalive": "^4.2.1",
+            "cacache": "^17.0.0",
             "http-cache-semantics": "^4.1.1",
+            "http-proxy-agent": "^5.0.0",
+            "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
-            "minipass": "^7.0.2",
+            "lru-cache": "^7.7.1",
+            "minipass": "^5.0.0",
             "minipass-fetch": "^3.0.0",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
+            "socks-proxy-agent": "^7.0.0",
             "ssri": "^10.0.0"
           }
         },
@@ -21273,7 +21676,7 @@
           }
         },
         "minipass": {
-          "version": "7.0.4",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true
         },
@@ -21296,12 +21699,12 @@
           }
         },
         "minipass-fetch": {
-          "version": "3.0.4",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "encoding": "^0.1.13",
-            "minipass": "^7.0.3",
+            "minipass": "^5.0.0",
             "minipass-sized": "^1.0.3",
             "minizlib": "^2.1.2"
           }
@@ -21459,60 +21862,6 @@
                 "concat-map": "0.0.1"
               }
             },
-            "cacache": {
-              "version": "17.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "@npmcli/fs": "^3.1.0",
-                "fs-minipass": "^3.0.0",
-                "glob": "^10.2.2",
-                "lru-cache": "^7.7.1",
-                "minipass": "^7.0.3",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "p-map": "^4.0.0",
-                "ssri": "^10.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^3.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0"
-                  }
-                },
-                "glob": {
-                  "version": "10.3.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "foreground-child": "^3.1.0",
-                    "jackspeak": "^2.0.3",
-                    "minimatch": "^9.0.1",
-                    "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-                    "path-scurry": "^1.10.1"
-                  }
-                },
-                "minimatch": {
-                  "version": "9.0.3",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "^2.0.1"
-                  }
-                },
-                "minipass": {
-                  "version": "7.0.4",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
             "gauge": {
               "version": "4.0.4",
               "bundled": true,
@@ -21541,33 +21890,6 @@
                 "path-is-absolute": "^1.0.0"
               }
             },
-            "lru-cache": {
-              "version": "7.18.3",
-              "bundled": true,
-              "dev": true
-            },
-            "make-fetch-happen": {
-              "version": "11.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^17.0.0",
-                "http-cache-semantics": "^4.1.1",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^5.0.0",
-                "minipass-fetch": "^3.0.0",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^7.0.0",
-                "ssri": "^10.0.0"
-              }
-            },
             "minimatch": {
               "version": "3.1.2",
               "bundled": true,
@@ -21575,11 +21897,6 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
-            },
-            "minipass": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
             },
             "nopt": {
               "version": "6.0.0",
@@ -21634,11 +21951,11 @@
           }
         },
         "normalize-package-data": {
-          "version": "6.0.0",
+          "version": "5.0.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^7.0.0",
+            "hosted-git-info": "^6.0.0",
             "is-core-module": "^2.8.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4"
@@ -21658,7 +21975,7 @@
           }
         },
         "npm-install-checks": {
-          "version": "6.3.0",
+          "version": "6.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21671,18 +21988,18 @@
           "dev": true
         },
         "npm-package-arg": {
-          "version": "11.0.1",
+          "version": "10.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "^7.0.0",
+            "hosted-git-info": "^6.0.0",
             "proc-log": "^3.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^5.0.0"
           }
         },
         "npm-packlist": {
-          "version": "8.0.0",
+          "version": "7.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21690,36 +22007,36 @@
           }
         },
         "npm-pick-manifest": {
-          "version": "9.0.0",
+          "version": "8.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
             "npm-install-checks": "^6.0.0",
             "npm-normalize-package-bin": "^3.0.0",
-            "npm-package-arg": "^11.0.0",
+            "npm-package-arg": "^10.0.0",
             "semver": "^7.3.5"
           }
         },
         "npm-profile": {
-          "version": "9.0.0",
+          "version": "7.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "npm-registry-fetch": "^16.0.0",
+            "npm-registry-fetch": "^14.0.0",
             "proc-log": "^3.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "16.1.0",
+          "version": "14.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "make-fetch-happen": "^13.0.0",
-            "minipass": "^7.0.2",
+            "make-fetch-happen": "^11.0.0",
+            "minipass": "^5.0.0",
             "minipass-fetch": "^3.0.0",
             "minipass-json-stream": "^1.0.1",
             "minizlib": "^2.1.2",
-            "npm-package-arg": "^11.0.0",
+            "npm-package-arg": "^10.0.0",
             "proc-log": "^3.0.0"
           }
         },
@@ -21756,26 +22073,26 @@
           }
         },
         "pacote": {
-          "version": "17.0.4",
+          "version": "15.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^5.0.0",
+            "@npmcli/git": "^4.0.0",
             "@npmcli/installed-package-contents": "^2.0.1",
-            "@npmcli/promise-spawn": "^7.0.0",
-            "@npmcli/run-script": "^7.0.0",
-            "cacache": "^18.0.0",
+            "@npmcli/promise-spawn": "^6.0.1",
+            "@npmcli/run-script": "^6.0.0",
+            "cacache": "^17.0.0",
             "fs-minipass": "^3.0.0",
-            "minipass": "^7.0.2",
-            "npm-package-arg": "^11.0.0",
-            "npm-packlist": "^8.0.0",
-            "npm-pick-manifest": "^9.0.0",
-            "npm-registry-fetch": "^16.0.0",
+            "minipass": "^5.0.0",
+            "npm-package-arg": "^10.0.0",
+            "npm-packlist": "^7.0.0",
+            "npm-pick-manifest": "^8.0.0",
+            "npm-registry-fetch": "^14.0.0",
             "proc-log": "^3.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json": "^7.0.0",
+            "read-package-json": "^6.0.0",
             "read-package-json-fast": "^3.0.0",
-            "sigstore": "^2.0.0",
+            "sigstore": "^1.3.0",
             "ssri": "^10.0.0",
             "tar": "^6.1.11"
           }
@@ -21801,12 +22118,19 @@
           "dev": true
         },
         "path-scurry": {
-          "version": "1.10.1",
+          "version": "1.9.2",
           "bundled": true,
           "dev": true,
           "requires": {
-            "lru-cache": "^9.1.1 || ^10.0.0",
-            "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            "lru-cache": "^9.1.1",
+            "minipass": "^5.0.0 || ^6.0.2"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "9.1.1",
+              "bundled": true,
+              "dev": true
+            }
           }
         },
         "postcss-selector-parser": {
@@ -21879,13 +22203,13 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "7.0.0",
+          "version": "6.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "^10.2.2",
             "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^6.0.0",
+            "normalize-package-data": "^5.0.0",
             "npm-normalize-package-bin": "^3.0.0"
           }
         },
@@ -21899,15 +22223,14 @@
           }
         },
         "readable-stream": {
-          "version": "4.4.2",
+          "version": "4.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "buffer": "^6.0.3",
             "events": "^3.3.0",
-            "process": "^0.11.10",
-            "string_decoder": "^1.3.0"
+            "process": "^0.11.10"
           }
         },
         "retry": {
@@ -22008,14 +22331,15 @@
           "dev": true
         },
         "sigstore": {
-          "version": "2.1.0",
+          "version": "1.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@sigstore/bundle": "^2.1.0",
-            "@sigstore/protobuf-specs": "^0.2.1",
-            "@sigstore/sign": "^2.1.0",
-            "@sigstore/tuf": "^2.1.0"
+            "@sigstore/bundle": "^1.1.0",
+            "@sigstore/protobuf-specs": "^0.2.0",
+            "@sigstore/sign": "^1.0.0",
+            "@sigstore/tuf": "^1.0.3",
+            "make-fetch-happen": "^11.0.1"
           }
         },
         "smart-buffer": {
@@ -22066,16 +22390,16 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.16",
+          "version": "3.0.13",
           "bundled": true,
           "dev": true
         },
         "ssri": {
-          "version": "10.0.5",
+          "version": "10.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "minipass": "^7.0.3"
+            "minipass": "^5.0.0"
           }
         },
         "string_decoder": {
@@ -22128,7 +22452,7 @@
           "dev": true
         },
         "tar": {
-          "version": "6.2.0",
+          "version": "6.1.15",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22157,11 +22481,6 @@
                   }
                 }
               }
-            },
-            "minipass": {
-              "version": "5.0.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -22181,13 +22500,13 @@
           "dev": true
         },
         "tuf-js": {
-          "version": "2.1.0",
+          "version": "1.1.7",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@tufjs/models": "2.0.0",
+            "@tufjs/models": "1.0.4",
             "debug": "^4.3.4",
-            "make-fetch-happen": "^13.0.0"
+            "make-fetch-happen": "^11.1.1"
           }
         },
         "unique-filename": {
@@ -22242,18 +22561,11 @@
           }
         },
         "which": {
-          "version": "4.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "isexe": "^3.1.1"
-          },
-          "dependencies": {
-            "isexe": {
-              "version": "3.1.1",
-              "bundled": true,
-              "dev": true
-            }
+            "isexe": "^2.0.0"
           }
         },
         "wide-align": {
@@ -22678,6 +22990,12 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -22720,6 +23038,18 @@
           "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
           "dev": true
         },
+        "normalize-package-data": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+          "integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^7.0.0",
+            "is-core-module": "^2.8.1",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
         "parse-json": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.1.0.tgz",
@@ -22739,6 +23069,15 @@
               "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
               "dev": true
             }
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "type-fest": {
@@ -22824,6 +23163,24 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        }
       }
     },
     "redeyed": {
@@ -22981,20 +23338,20 @@
       "dev": true
     },
     "semantic-release": {
-      "version": "22.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.5.tgz",
-      "integrity": "sha512-ESCEQsZlBj1DWMA84RthaJzQHHnihoGk49s9nUxHfRNUNZelLE9JZrE94bHO2Y00EWb7iwrzr1OYhv5QNVmf8A==",
+      "version": "21.1.2",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-21.1.2.tgz",
+      "integrity": "sha512-kz76azHrT8+VEkQjoCBHE06JNQgTgsC4bT8XfCzb7DHcsk9vG3fqeMVik8h5rcWCYi2Fd+M3bwA7BG8Z8cRwtA==",
       "dev": true,
       "requires": {
-        "@semantic-release/commit-analyzer": "^11.0.0",
+        "@semantic-release/commit-analyzer": "^10.0.0",
         "@semantic-release/error": "^4.0.0",
         "@semantic-release/github": "^9.0.0",
-        "@semantic-release/npm": "^11.0.0",
-        "@semantic-release/release-notes-generator": "^12.0.0",
+        "@semantic-release/npm": "^10.0.2",
+        "@semantic-release/release-notes-generator": "^11.0.0",
         "aggregate-error": "^5.0.0",
         "cosmiconfig": "^8.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^10.0.0",
+        "env-ci": "^9.0.0",
         "execa": "^8.0.0",
         "figures": "^5.0.0",
         "find-versions": "^5.1.0",
@@ -23003,8 +23360,8 @@
         "hook-std": "^3.0.0",
         "hosted-git-info": "^7.0.0",
         "lodash-es": "^4.17.21",
-        "marked": "^9.0.0",
-        "marked-terminal": "^6.0.0",
+        "marked": "^5.0.0",
+        "marked-terminal": "^5.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^3.0.0",
         "p-reduce": "^3.0.0",
@@ -23183,15 +23540,6 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
-    "skin-tone": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
-      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-      "dev": true,
-      "requires": {
-        "unicode-emoji-modifier-base": "^1.0.0"
-      }
-    },
     "slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -23251,6 +23599,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
       "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
       "dev": true
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
     },
     "split2": {
       "version": "4.2.0",
@@ -23342,6 +23699,15 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -23355,6 +23721,33 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
+      "integrity": "sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "temp-dir": {
@@ -23445,6 +23838,12 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
     },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
+    },
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -23499,12 +23898,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
       "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
-      "dev": true
-    },
-    "unicode-emoji-modifier-base": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
-      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
       "dev": true
     },
     "unicode-match-property-ecmascript": {
@@ -23719,6 +24112,12 @@
           "dev": true
         }
       }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "eslint": "^8.52.0",
     "eslint-plugin-jest": "^27.4.3",
     "jest": "^29.7.0",
-    "semantic-release": "^22.0.5"
+    "semantic-release": "^21.1.2"
   }
 }


### PR DESCRIPTION
Attempt to fix this error when releasing.

```
Error: Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/_actions/cycjimmy/semantic-release-action/v2/node_modules/semantic-release/index.js from /home/runner/work/_actions/cycjimmy/semantic-release-action/v2/src/index.js not supported.
```

ES Module seems to be removed in v22 [[Ref](https://github.com/semantic-release/semantic-release/releases/tag/v22.0.3)] which caused incompatibility with cycjimmy/semantic-release-action@v2.